### PR TITLE
I/O_DS yaml files to support bb_attributes: iopad_external_pin

### DIFF
--- a/models_internal/verilog_blackbox/cell_sim_blackbox.v
+++ b/models_internal/verilog_blackbox/cell_sim_blackbox.v
@@ -268,8 +268,11 @@ module I_BUF_DS #(
   parameter DIFFERENTIAL_TERMINATION = "TRUE" // Enable differential termination
 `endif // RAPIDSILICON_INTERNAL
   ) (
+  (* iopad_external_pin *)
   input logic I_P,
+  (* iopad_external_pin *)
   input logic I_N,
+  (* iopad_external_pin *)
   input logic EN,
   output reg O
 );
@@ -475,7 +478,9 @@ module O_BUF_DS
 `endif // RAPIDSILICON_INTERNAL
   (
   input logic I,
+  (* iopad_external_pin *)
   output logic O_P,
+  (* iopad_external_pin *)
   output logic O_N
 );
 endmodule
@@ -497,7 +502,9 @@ module O_BUFT_DS #(
   ) (
   input logic I,
   input logic T,
+  (* iopad_external_pin *)
   output logic O_P,
+  (* iopad_external_pin *)
   output logic O_N
 );
 endmodule

--- a/specs/I_BUF_DS.yaml
+++ b/specs/I_BUF_DS.yaml
@@ -51,12 +51,15 @@ ports:
    I_P:
      dir: input
      desc: Data positive input (connect to top-level port)
+     bb_attributes: iopad_external_pin
    I_N:
      dir: input
      desc: Data negative input (connect to top-level port)
+     bb_attributes: iopad_external_pin
    EN:
      dir: input
      desc: Enable the input
+     bb_attributes: iopad_external_pin
    O:
      dir: output
      type: reg

--- a/specs/O_BUFT_DS.yaml
+++ b/specs/O_BUFT_DS.yaml
@@ -57,9 +57,11 @@ ports:
    O_P:
      dir: output
      desc: Data positive output (connect to top-level port)
+     bb_attributes: iopad_external_pin
    O_N:
      dir: output
      desc: Data negative output (connect to top-level port)
+     bb_attributes: iopad_external_pin
 
 parameters:
    WEAK_KEEPER:

--- a/specs/O_BUF_DS.yaml
+++ b/specs/O_BUF_DS.yaml
@@ -54,9 +54,11 @@ ports:
    O_P:
      dir: output
      desc: Data positive output (connect to top-level port)
+     bb_attributes: iopad_external_pin
    O_N:
      dir: output
      desc: Data negative output (connect to top-level port)
+     bb_attributes: iopad_external_pin
   
 
 # set in SDC or by synthesis attribute      


### PR DESCRIPTION
- EDA-2652 fixes