### PR TITLE
Adding attribute to infer clk_buf for PLL clk_in

### DIFF
--- a/models_internal/verilog_blackbox/cell_sim_blackbox.v
+++ b/models_internal/verilog_blackbox/cell_sim_blackbox.v
@@ -670,6 +670,7 @@ module PLL #(
   parameter PLL_POST_DIV = 2 // VCO clock post-divider value (2,4,6,8,10,12,14,16,18,20,24,28,30,32,36,40,42,48,50,56,60,70,72,84,98)
   ) (
   input logic PLL_EN,
+  (* clkbuf_sink *)
   input logic CLK_IN,
   output reg CLK_OUT,
   output reg CLK_OUT_DIV2,

--- a/specs/PLL.yaml
+++ b/specs/PLL.yaml
@@ -55,6 +55,7 @@ ports:
    CLK_IN:
      dir: input
      desc: Clock input
+     bb_attributes: clkbuf_sink
    CLK_OUT:
      dir: output
      desc: Output clock, frequency is CLK_IN_FREQ*PLL_MULT/PLL_DIV/PLL_POST_DIV


### PR DESCRIPTION
- EDA-2907 fix